### PR TITLE
Wazo 2840 remove python2 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Running unit tests
 ------------------
 
 ```
-apt-get install libpq-dev python-dev libffi-dev libyaml-dev
+apt-get install libpq-dev python3-dev libffi-dev libyaml-dev
 pip install tox
-tox --recreate -e py27
+tox --recreate -e py37
 ```

--- a/debian/control
+++ b/debian/control
@@ -5,26 +5,10 @@ Maintainer: Wazo Maintainers <dev@wazo.community>
 Build-Depends: 
  debhelper (>= 9),
  dh-python,
- python-all (>= 2.7),
- python-setuptools,
  python3-all,
  python3-setuptools
 Standards-Version: 3.9.6
-X-Python-Version: >= 2.7
 X-Python3-Version: >= 3.4
-
-Package: wazo-amid-client
-Architecture: all
-Section: python
-Depends:
-  ${python:Depends},
-  ${misc:Depends},
-  wazo-lib-rest-client,
-  python-requests,
-  python-stevedore
-Description: wazo-amid client library in python
- Wazo is a system based on a powerful IPBX, to bring an easy to
- install solution for telephony and related services.
 
 Package: wazo-amid-client-python3
 Architecture: all

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends:
  python3-all,
  python3-setuptools
 Standards-Version: 3.9.6
-X-Python3-Version: >= 3.4
+X-Python3-Version: >= 3.7
 
 Package: wazo-amid-client-python3
 Architecture: all

--- a/debian/rules
+++ b/debian/rules
@@ -2,9 +2,8 @@
 # -*- makefile -*-
 
 export PYBUILD_NAME=wazo_amid_client
-export PYBUILD_DESTDIR_python2=debian/wazo-amid-client/
 export PYBUILD_DESTDIR_python3=debian/wazo-amid-client-python3/
 export PYBUILD_DISABLE=test
 
 %:
-	dh $@ --with python2,python3 --buildsystem=pybuild
+	dh $@ --with python3 --buildsystem=pybuild

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 # Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
-mock
 pyhamcrest
 pytest

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py27, pycodestyle, pylint
+envlist = py37, pycodestyle, pylint
 skipsdist=True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -15,25 +15,6 @@ deps =
     -rtest-requirements.txt
     pytest-cov
 
-[testenv:pycodestyle]
-# E501: line too long (80 chars)
-commands =
-    -sh -c 'pycodestyle --ignore=E501 wazo_amid_client > pycodestyle.txt'
-deps =
-    pycodestyle
-whitelist_externals =
-    sh
-
-[testenv:pylint]
-commands =
-    -sh -c 'pylint --rcfile=/usr/share/xivo-ci/pylintrc wazo_amid_client > pylint.txt'
-deps =
-    -rrequirements.txt
-    -rtest-requirements.txt
-    pylint
-whitelist_externals =
-    sh
-
 [testenv:linters]
 skip_install = true
 deps =

--- a/wazo_amid_client/__init__.py
+++ b/wazo_amid_client/__init__.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2014-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_amid_client.client import AmidClient as Client

--- a/wazo_amid_client/client.py
+++ b/wazo_amid_client/client.py
@@ -9,6 +9,4 @@ class AmidClient(BaseClient):
     namespace = 'wazo_amid_client.commands'
 
     def __init__(self, host, port=443, prefix='/api/amid', version='1.0', **kwargs):
-        super().__init__(
-            host=host, port=port, prefix=prefix, version=version, **kwargs
-        )
+        super().__init__(host=host, port=port, prefix=prefix, version=version, **kwargs)

--- a/wazo_amid_client/client.py
+++ b/wazo_amid_client/client.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_lib_rest_client.client import BaseClient
@@ -10,6 +9,6 @@ class AmidClient(BaseClient):
     namespace = 'wazo_amid_client.commands'
 
     def __init__(self, host, port=443, prefix='/api/amid', version='1.0', **kwargs):
-        super(AmidClient, self).__init__(
+        super().__init__(
             host=host, port=port, prefix=prefix, version=version, **kwargs
         )

--- a/wazo_amid_client/command.py
+++ b/wazo_amid_client/command.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2020-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_lib_rest_client.command import RESTCommand

--- a/wazo_amid_client/commands/__init__.py
+++ b/wazo_amid_client/commands/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2015 Avencall
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/wazo_amid_client/commands/action.py
+++ b/wazo_amid_client/commands/action.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_amid_client.command import AmidCommand
@@ -10,7 +9,7 @@ class ActionCommand(AmidCommand):
     resource = 'action'
 
     def __call__(self, action, params=None, **kwargs):
-        url = '{base}/{action}'.format(base=self.base_url, action=action)
+        url = f'{self.base_url}/{action}'
         r = self.session.post(url, json=params, params=kwargs)
 
         if r.status_code != 200:

--- a/wazo_amid_client/commands/command.py
+++ b/wazo_amid_client/commands/command.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_amid_client.command import AmidCommand
@@ -11,7 +10,7 @@ class CommandCommand(AmidCommand):
 
     def __call__(self, command):
         body = {'command': command}
-        url = '{base}/Command'.format(base=self.base_url)
+        url = f'{self.base_url}/Command'
         r = self.session.post(url, json=body)
 
         if r.status_code != 200:

--- a/wazo_amid_client/commands/status.py
+++ b/wazo_amid_client/commands/status.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_amid_client/commands/tests/__init__.py
+++ b/wazo_amid_client/commands/tests/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2015 Avencall
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/wazo_amid_client/commands/tests/test_action.py
+++ b/wazo_amid_client/commands/tests/test_action.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2014-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that
@@ -22,7 +21,7 @@ class TestAction(RESTCommandTestCase):
         result = self.command('QueueSummary')
 
         self.session.post.assert_called_once_with(
-            '{base}/QueueSummary'.format(base=self.base_url), params={}, json=None
+            f'{self.base_url}/QueueSummary', params={}, json=None
         )
         assert_that(result, equal_to([{'return': 'value'}]))
 
@@ -34,7 +33,7 @@ class TestAction(RESTCommandTestCase):
         result = self.command('DBGet', {'Family': 'family', 'Key': 'key'})
 
         self.session.post.assert_called_once_with(
-            '{base}/DBGet'.format(base=self.base_url),
+            f'{self.base_url}/DBGet',
             params={},
             json={'Family': 'family', 'Key': 'key'},
         )

--- a/wazo_amid_client/commands/tests/test_command.py
+++ b/wazo_amid_client/commands/tests/test_command.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that
@@ -23,7 +22,7 @@ class TestCommand(RESTCommandTestCase):
         result = self.command(asterisk_command)
 
         self.session.post.assert_called_once_with(
-            '{base}/Command'.format(base=self.base_url),
+            f'{self.base_url}/Command',
             json={'command': asterisk_command},
         )
         assert_that(result, equal_to({'return': 'value'}))

--- a/wazo_amid_client/commands/tests/test_status.py
+++ b/wazo_amid_client/commands/tests/test_status.py
@@ -6,7 +6,6 @@ from hamcrest import equal_to
 
 from wazo_lib_rest_client.tests.command import RESTCommandTestCase
 
-from ..command import CommandCommand
 from ..status import StatusCommand
 
 

--- a/wazo_amid_client/commands/tests/test_status.py
+++ b/wazo_amid_client/commands/tests/test_status.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,6 +20,6 @@ class TestStatus(RESTCommandTestCase):
         result = self.command()
 
         self.session.get.assert_called_once_with(
-            '{base}'.format(base=self.base_url), headers={'Accept': 'application/json'}
+            f'{self.base_url}', headers={'Accept': 'application/json'}
         )
         assert_that(result, equal_to(json_response))

--- a/wazo_amid_client/exceptions.py
+++ b/wazo_amid_client/exceptions.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2020-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from requests import HTTPError
@@ -23,8 +22,8 @@ class AmidError(HTTPError):
         except KeyError:
             raise InvalidAmidError()
 
-        exception_message = '{e.message}: {e.details}'.format(e=self)
-        super(AmidError, self).__init__(exception_message, response=response)
+        exception_message = f'{self.message}: {self.details}'
+        super().__init__(exception_message, response=response)
 
 
 class AmidServiceUnavailable(AmidError):
@@ -44,8 +43,7 @@ class AmidProtocolError(AmidError):
         except (TypeError, KeyError):
             raise InvalidAmidError()
 
-        exception_message = '{e.message}'.format(e=self)
-        super(HTTPError, self).__init__(exception_message, response=response)
+        super().__init__(f'{self.message}', response=response)
 
 
 class InvalidAmidError(Exception):

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -1,5 +1,4 @@
 - project:
     templates:
-      - wazo-tox-py27
       - wazo-tox-py37
       - debian-packaging-template

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -1,5 +1,5 @@
 - project:
     templates:
-      - wazo-tox-py37
       - wazo-tox-linters
+      - wazo-tox-py37
       - debian-packaging-template

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -1,4 +1,5 @@
 - project:
     templates:
       - wazo-tox-py37
+      - wazo-tox-linters
       - debian-packaging-template


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/wazo-lib-rest-client/pull/12