### PR TITLE
WP-2105-replace-union

### DIFF
--- a/wazo_amid_client/types.py
+++ b/wazo_amid_client/types.py
@@ -3,6 +3,6 @@
 
 from __future__ import annotations
 
-from typing import TypeAlias, Union
+from typing import TypeAlias
 
-JSON: TypeAlias = Union[str, int, float, bool, None, list['JSON'], dict[str, 'JSON']]
+JSON: TypeAlias = str | int | float | bool | None | list['JSON'] | dict[str, 'JSON']


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch `JSON` TypeAlias to PEP 604 `|` unions and drop `Union` import in `wazo_amid_client/types.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e608a8be6e3ae934186f6203772a57fe7834d988. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->